### PR TITLE
Added code editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
         "@fontsource/roboto": "^5.0.8",
+        "@monaco-editor/react": "^4.6.0",
         "@mui/icons-material": "^5.14.15",
         "@mui/material": "^5.14.15",
         "@types/node": "20.8.9",
@@ -32,6 +33,9 @@
         "recoil": "^0.7.7",
         "tailwindcss": "3.3.5",
         "typescript": "5.2.2"
+      },
+      "peerDependencies": {
+        "monaco-editor": "^0.44.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -1075,6 +1079,30 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@monaco-editor/loader": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.4.0.tgz",
+      "integrity": "sha512-00ioBig0x642hytVspPl7DbQyaSWRaolYie/UFNjoTdvoKPzo6xrXLhTk9ixgIKcLH5b5vDOjVNiGyY+uDCUlg==",
+      "dependencies": {
+        "state-local": "^1.0.6"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">= 0.21.0 < 1"
+      }
+    },
+    "node_modules/@monaco-editor/react": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.6.0.tgz",
+      "integrity": "sha512-RFkU9/i7cN2bsq/iTkurMWOEErmYcY6JiQI3Jn+WeR/FGISH8JbHERjpS9oRuSOPvDMJI0Z8nJeKkbOs9sBYQw==",
+      "dependencies": {
+        "@monaco-editor/loader": "^1.4.0"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">= 0.25.0 < 1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@mui/base": {
@@ -4159,6 +4187,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/monaco-editor": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.44.0.tgz",
+      "integrity": "sha512-5SmjNStN6bSuSE5WPT2ZV+iYn1/yI9sd4Igtk23ChvqB7kDk9lZbB9F5frsuvpB+2njdIeGGFf2G4gbE6rCC9Q==",
+      "peer": true
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -5192,6 +5226,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/state-local": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
+      "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w=="
     },
     "node_modules/streamsearch": {
       "version": "1.1.0",
@@ -6763,6 +6802,22 @@
       "requires": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "@monaco-editor/loader": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.4.0.tgz",
+      "integrity": "sha512-00ioBig0x642hytVspPl7DbQyaSWRaolYie/UFNjoTdvoKPzo6xrXLhTk9ixgIKcLH5b5vDOjVNiGyY+uDCUlg==",
+      "requires": {
+        "state-local": "^1.0.6"
+      }
+    },
+    "@monaco-editor/react": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.6.0.tgz",
+      "integrity": "sha512-RFkU9/i7cN2bsq/iTkurMWOEErmYcY6JiQI3Jn+WeR/FGISH8JbHERjpS9oRuSOPvDMJI0Z8nJeKkbOs9sBYQw==",
+      "requires": {
+        "@monaco-editor/loader": "^1.4.0"
       }
     },
     "@mui/base": {
@@ -8893,6 +8948,12 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
     },
+    "monaco-editor": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.44.0.tgz",
+      "integrity": "sha512-5SmjNStN6bSuSE5WPT2ZV+iYn1/yI9sd4Igtk23ChvqB7kDk9lZbB9F5frsuvpB+2njdIeGGFf2G4gbE6rCC9Q==",
+      "peer": true
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -9540,6 +9601,11 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
       "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw=="
+    },
+    "state-local": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
+      "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w=="
     },
     "streamsearch": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
     "@fontsource/roboto": "^5.0.8",
+    "@monaco-editor/react": "^4.6.0",
     "@mui/icons-material": "^5.14.15",
     "@mui/material": "^5.14.15",
     "@types/node": "20.8.9",
@@ -33,5 +34,8 @@
     "recoil": "^0.7.7",
     "tailwindcss": "3.3.5",
     "typescript": "5.2.2"
+  },
+  "peerDependencies": {
+    "monaco-editor": "^0.44.0"
   }
 }

--- a/src/components/Modals/SettingsModal.tsx
+++ b/src/components/Modals/SettingsModal.tsx
@@ -1,0 +1,132 @@
+import { ISettings } from "@/components/Workspace/CodeEditor/CodeEditor";
+import { SetStateAction, useState } from "react";
+import Modal from "@mui/material/Modal";
+import Typography from "@mui/material/Typography";
+import IconButton from "@mui/material/IconButton";
+import CloseIcon from "@mui/icons-material/Close";
+import Select, { SelectChangeEvent } from "@mui/material/Select";
+import MenuItem from "@mui/material/MenuItem";
+import InputLabel from "@mui/material/InputLabel";
+import { Button } from "@mui/material";
+
+const EDITOR_FONT_SIZES = [
+  "12px",
+  "13px",
+  "14px",
+  "15px",
+  "16px",
+  "17px",
+  "18px",
+  "20px",
+  "22px",
+  "24px",
+  "28px",
+  "32px",
+];
+
+interface SettingsModalProps {
+  settings: ISettings;
+  setSettings: (
+    setStateValue: SetStateAction<ISettings>,
+    fontSizeForLocalData?: string
+  ) => void;
+}
+
+const SettingsModal: React.FC<SettingsModalProps> = ({
+  setSettings,
+  settings,
+}) => {
+  const [localFontSize, setLocalFontSize] = useState(settings.fontSize);
+  const open = settings.settingsModalIsOpen;
+  const handleClose = () => {
+    setLocalFontSize(settings.fontSize);
+    setSettings((prev) => ({ ...prev, settingsModalIsOpen: false }));
+  };
+
+  const handleFontSizeMenuItemClick = (event: SelectChangeEvent) => {
+    setLocalFontSize(event.target.value as string);
+  };
+
+  const handleSaveButtonClick = () => {
+    setSettings(
+      (prev) => ({
+        ...prev,
+        settingsModalIsOpen: false,
+        fontSize: localFontSize,
+      }),
+      localFontSize
+    );
+  };
+  return (
+    <div>
+      <Modal
+        open={open}
+        onClose={handleClose}
+        aria-labelledby="modal-modal-title"
+        aria-describedby="modal-modal-description"
+      >
+        <div className="bg-gray-700 w-full max-w-md mx-auto mt-16 rounded-lg shadow-lg text-gray-50">
+          <div className="flex justify-between items-center m-4">
+            <Typography variant="h6">Settings</Typography>
+            <IconButton
+              aria-label="toggle password visibility"
+              onClick={handleClose}
+            >
+              <CloseIcon className="text-gray-100" />
+            </IconButton>
+          </div>
+          <div className="m-4">
+            <div className="flex items-center gap-6">
+              <InputLabel
+                id="settings-font-size-select-label"
+                className="text-gray-50 text-lg"
+              >
+                Font Size
+              </InputLabel>
+              <Select
+                labelId="settings-font-size-select-label"
+                id="settings-font-size-select"
+                value={localFontSize}
+                onChange={handleFontSizeMenuItemClick}
+                sx={{
+                  color: "white",
+                  ".MuiOutlinedInput-notchedOutline": {
+                    borderColor: "rgba(228, 219, 233, 0.25)",
+                  },
+                  "&.Mui-focused .MuiOutlinedInput-notchedOutline": {
+                    borderColor: "rgba(228, 219, 233, 0.25)",
+                  },
+                  "&:hover .MuiOutlinedInput-notchedOutline": {
+                    borderColor: "rgba(228, 219, 233, 0.25)",
+                  },
+                  ".MuiSvgIcon-root ": {
+                    fill: "white !important",
+                  },
+                }}
+              >
+                {EDITOR_FONT_SIZES.map((fontSize, index) => (
+                  <MenuItem
+                    value={fontSize}
+                    key={`settings-font-size-item${index}`}
+                  >
+                    {fontSize}
+                  </MenuItem>
+                ))}
+              </Select>
+            </div>
+          </div>
+          <div className="flex">
+            <Button
+              className="ml-auto mr-5 mb-6"
+              variant="contained"
+              onClick={handleSaveButtonClick}
+            >
+              Save
+            </Button>
+          </div>
+        </div>
+      </Modal>
+    </div>
+  );
+};
+export default SettingsModal;

--- a/src/components/Workspace/CodeEditor/CodeEditor.tsx
+++ b/src/components/Workspace/CodeEditor/CodeEditor.tsx
@@ -1,0 +1,111 @@
+import React, {
+  Dispatch,
+  MouseEventHandler,
+  SetStateAction,
+  useEffect,
+  useState,
+} from "react";
+import { TFormattedQuestion, TFormattedSolution } from "@/utils/types/question";
+import PreferenceNav from "./PreferenceNav";
+import useLocalStorage from "@/hooks/useLocalStorage";
+import { useAuthState } from "react-firebase-hooks/auth";
+import { auth } from "@/firebase/firebase";
+import Editor from "@monaco-editor/react";
+import { editor } from "monaco-editor";
+
+type CodeEditorProps = {
+  problem: TFormattedQuestion;
+  selectedLanguage: TFormattedSolution;
+  setSelectedLanguage: Dispatch<SetStateAction<TFormattedSolution>>;
+  setUserCode: Dispatch<SetStateAction<string>>;
+  userCode: string;
+};
+
+export interface ISettings {
+  fontSize: string;
+  settingsModalIsOpen: boolean;
+  dropdownIsOpen: boolean;
+}
+
+const CodeEditor: React.FC<CodeEditorProps> = ({
+  problem,
+  selectedLanguage,
+  setSelectedLanguage,
+  setUserCode,
+  userCode,
+}) => {
+  const [user] = useAuthState(auth);
+  const localCodeStorageKey = `code-${user?.uid}-${problem.id}-${selectedLanguage.languageId}`;
+  const [fontSize, setFontSize] = useLocalStorage("lcc-fontSize", "16px");
+
+  const [settings, setSettings] = useState<ISettings>({
+    fontSize: fontSize,
+    settingsModalIsOpen: false,
+    dropdownIsOpen: false,
+  });
+
+  useEffect(() => {
+    const item = window.localStorage.getItem(localCodeStorageKey);
+    if (item) {
+      setUserCode(item);
+    }
+  }, []);
+
+  const getLanguageExtension = (selectedLanguage: TFormattedSolution) => {
+    const langName = selectedLanguage.languageName
+      .replace(/\(.*?\)/, "")
+      .trim()
+      .toLowerCase();
+
+    return langName === "c++" ? "cpp" : langName;
+  };
+
+  const selectedLangName = getLanguageExtension(selectedLanguage);
+
+  const onChange = (value: string | undefined) => {
+    setUserCode(value || "");
+    localStorage.setItem(localCodeStorageKey, value || "");
+  };
+
+  const editorOptions: editor.IStandaloneEditorConstructionOptions = {
+    fontSize: parseInt(settings.fontSize) || 16,
+    automaticLayout: true,
+  };
+
+  const onResetCode: MouseEventHandler<HTMLAnchorElement> = (event) => {
+    event.preventDefault();
+    const resetCode = `${selectedLanguage.starterCode}${"\n".repeat(15)}`;
+    setUserCode(resetCode);
+    localStorage.setItem(localCodeStorageKey, resetCode);
+  };
+
+  useEffect(() => {
+    const localCodeSnippet = localStorage.getItem(localCodeStorageKey);
+    const code =
+      localCodeSnippet || `${selectedLanguage.starterCode}${"\n".repeat(15)}`;
+    localStorage.setItem(localCodeStorageKey, code);
+    setUserCode(code);
+  }, [selectedLanguage]);
+
+  return (
+    <div className="flex flex-col bg-dark-layer-1 flex-1">
+      <PreferenceNav
+        setSelectedLanguage={setSelectedLanguage}
+        selectedLanguage={selectedLanguage}
+        settings={settings}
+        setSettings={setSettings}
+        languages={problem.solutions}
+        onResetCode={onResetCode}
+        setFontSize={setFontSize}
+      />
+      <Editor
+        theme="vs-dark"
+        language={selectedLangName}
+        value={userCode}
+        onChange={onChange}
+        options={editorOptions}
+      />
+    </div>
+  );
+};
+export default CodeEditor;

--- a/src/components/Workspace/CodeEditor/EditorFooter.tsx
+++ b/src/components/Workspace/CodeEditor/EditorFooter.tsx
@@ -1,0 +1,66 @@
+import React, { Dispatch, SetStateAction } from "react";
+import ExpandLessIcon from "@mui/icons-material/ExpandLess";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import Button from "@mui/material/Button";
+
+type EditorFooterProps = {
+  setActiveTabIndex: Dispatch<SetStateAction<number>>;
+  submitTestCases: Function;
+  setSubmitExecution: Dispatch<SetStateAction<boolean>>;
+  isRunning?: boolean;
+  handleCancel?: () => void;
+};
+
+const EditorFooter: React.FC<EditorFooterProps> = ({
+  setActiveTabIndex,
+  submitTestCases,
+  setSubmitExecution,
+  isRunning,
+  handleCancel,
+}) => {
+  const handleRun = () => {
+    // set console as the active tab (console is the 3rd tab)
+    setActiveTabIndex(2);
+    submitTestCases();
+    setSubmitExecution(false);
+  };
+
+  const handleSubmit = () => {
+    // set console as the active tab (console is the 3rd tab)
+    setActiveTabIndex(2);
+    submitTestCases();
+    setSubmitExecution(true);
+  };
+
+  return (
+    <div className="flex bg-dark-layer-1 w-full">
+      <div className="mx-5 my-[10px] flex justify-end w-full">
+        <div className="ml-auto flex items-center space-x-4">
+          {isRunning ? (
+            <Button
+              onClick={() => handleCancel && handleCancel()}
+              variant="contained"
+              color="error"
+            >
+              Stop
+            </Button>
+          ) : (
+            <>
+              <Button onClick={handleRun} variant="contained" color="warning">
+                Run
+              </Button>
+              <Button
+                onClick={handleSubmit}
+                variant="contained"
+                color="success"
+              >
+                Submit
+              </Button>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+export default EditorFooter;

--- a/src/components/Workspace/CodeEditor/PreferenceNav.tsx
+++ b/src/components/Workspace/CodeEditor/PreferenceNav.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import {
+  useState,
+  useEffect,
+  Dispatch,
+  SetStateAction,
+  MouseEventHandler,
+} from "react";
+import { ISettings } from "@/components/Workspace/CodeEditor/CodeEditor";
+import { TFormattedSolution } from "@/utils/types/question";
+import SettingsModal from "@/components/Modals/SettingsModal";
+import Select, { SelectChangeEvent } from "@mui/material/Select";
+import MenuItem from "@mui/material/MenuItem";
+import Button from "@mui/material/Button";
+import IconButton from "@mui/material/IconButton";
+import RestartAltIcon from "@mui/icons-material/RestartAlt";
+import FullscreenIcon from "@mui/icons-material/Fullscreen";
+import FullscreenExitIcon from "@mui/icons-material/FullscreenExit";
+import SettingsOutlinedIcon from "@mui/icons-material/SettingsOutlined";
+
+type PreferenceNavProps = {
+  settings: ISettings;
+  languages: TFormattedSolution[];
+  selectedLanguage: TFormattedSolution;
+  setSelectedLanguage: Dispatch<SetStateAction<TFormattedSolution>>;
+  setSettings: React.Dispatch<React.SetStateAction<ISettings>>;
+  onResetCode: MouseEventHandler<HTMLAnchorElement>;
+  setFontSize: any;
+};
+
+const PreferenceNav: React.FC<PreferenceNavProps> = ({
+  setSettings,
+  settings,
+  languages,
+  selectedLanguage,
+  setSelectedLanguage,
+  onResetCode,
+  setFontSize,
+}) => {
+  const [isFullScreen, setIsFullScreen] = useState(false);
+
+  const handleFullScreen = () => {
+    if (isFullScreen) {
+      document.exitFullscreen();
+    } else {
+      document.documentElement.requestFullscreen();
+    }
+    setIsFullScreen(!isFullScreen);
+  };
+
+  useEffect(() => {
+    function exitHandler(e: any) {
+      if (!document.fullscreenElement) {
+        setIsFullScreen(false);
+        return;
+      }
+      setIsFullScreen(true);
+    }
+
+    if (document.addEventListener) {
+      document.addEventListener("fullscreenchange", exitHandler);
+      document.addEventListener("webkitfullscreenchange", exitHandler);
+      document.addEventListener("mozfullscreenchange", exitHandler);
+      document.addEventListener("MSFullscreenChange", exitHandler);
+    }
+  }, [isFullScreen]);
+
+  const handleChange = (event: SelectChangeEvent<string>) => {
+    const newLang = languages.find(
+      (language) => language.languageId === event.target.value
+    );
+    newLang && setSelectedLanguage(newLang);
+  };
+
+  const setSettingsAndLocalData = (
+    setStateValue: SetStateAction<ISettings>,
+    fontSizeForLocalData?: string
+  ) => {
+    setSettings(setStateValue);
+    fontSizeForLocalData && setFontSize(fontSizeForLocalData);
+  };
+
+  return (
+    <>
+      <div className="flex items-center justify-between bg-slate-50 w-full p-2 py-1 flex-wrap">
+        <div className="flex flex-wrap">
+          <Select
+            value={selectedLanguage.languageId}
+            label="Select Languages"
+            variant="outlined"
+            size="small"
+            onChange={handleChange}
+          >
+            {languages.map(({ languageId, languageName }) => (
+              <MenuItem
+                color={"white"}
+                value={languageId}
+                key={`languages-to-select-${languageId}`}
+              >
+                {languageName}
+              </MenuItem>
+            ))}
+          </Select>
+          <IconButton
+            onClick={onResetCode}
+            title="Reset code"
+            type="button"
+            href="/"
+          >
+            <RestartAltIcon fontSize="medium" />
+          </IconButton>
+        </div>
+
+        <div className="flex items-center m-2 gap-2">
+          <Button
+            variant="outlined"
+            onClick={() =>
+              setSettings({ ...settings, settingsModalIsOpen: true })
+            }
+          >
+            <SettingsOutlinedIcon className="mr-2" />
+            Settings
+          </Button>
+
+          <Button variant="outlined" onClick={handleFullScreen}>
+            {!isFullScreen ? (
+              <FullscreenIcon className="mr-2" />
+            ) : (
+              <FullscreenExitIcon className="mr-2" />
+            )}{" "}
+            Full Screen
+          </Button>
+        </div>
+      </div>
+      {settings.settingsModalIsOpen && (
+        <SettingsModal
+          settings={settings}
+          setSettings={setSettingsAndLocalData}
+        />
+      )}
+    </>
+  );
+};
+export default PreferenceNav;

--- a/src/components/Workspace/Workspace.tsx
+++ b/src/components/Workspace/Workspace.tsx
@@ -4,7 +4,8 @@ import { useState } from "react";
 import { TFormattedQuestion } from "@/utils/types/question";
 import Tabs from "@mui/material/Tabs";
 import Tab from "@mui/material/Tab";
-import ProblemDescription from "./ProblemDescription/ProblemDescription";
+import ProblemDescription from "@/components/Workspace/ProblemDescription/ProblemDescription";
+import CodeEditor from "@/components/Workspace/CodeEditor/CodeEditor";
 
 interface TabPanelProps {
   children?: React.ReactNode;
@@ -40,6 +41,12 @@ type WorkspaceProps = {
 
 const Workspace: React.FC<WorkspaceProps> = ({ problem }) => {
   const [activeTabIndex, setActiveTabIndex] = useState<number>(0);
+  const [selectedLanguage, setSelectedLanguage] = useState(
+    problem.solutions[0]
+  );
+  const [userCode, setUserCode] = useState<string>(
+    `${selectedLanguage.starterCode}${"\n".repeat(15)}`
+  );
 
   function tabsA11yProps(index: number) {
     return {
@@ -67,8 +74,19 @@ const Workspace: React.FC<WorkspaceProps> = ({ problem }) => {
       <CustomTabPanel value={activeTabIndex} index={0}>
         <ProblemDescription problem={problem} />
       </CustomTabPanel>
-      <CustomTabPanel value={activeTabIndex} index={1}>
-        Code Editor
+      <CustomTabPanel
+        value={activeTabIndex}
+        index={1}
+        contentNotScrollable
+        className="bg-dark-layer-1 flex justify-between flex-col h-full"
+      >
+        <CodeEditor
+          problem={problem}
+          selectedLanguage={selectedLanguage}
+          setSelectedLanguage={setSelectedLanguage}
+          setUserCode={setUserCode}
+          userCode={userCode}
+        />
       </CustomTabPanel>
       <CustomTabPanel value={activeTabIndex} index={2}>
         Console

--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -1,0 +1,33 @@
+"use client"
+
+import { useState, useEffect } from "react";
+
+const useLocalStorage = (key: string, initialValue: string) => {
+	const [value, setValue] = useState(() => {
+		try {
+			if (typeof window !== "undefined") {
+				const item = window.localStorage.getItem(key);
+				return item ? JSON.parse(item) : initialValue;
+			} else {
+				return initialValue;
+			}
+		} catch (error) {
+			console.error(error);
+			return initialValue;
+		}
+	});
+
+	useEffect(() => {
+		try {
+			if (typeof window !== "undefined") {
+				window.localStorage.setItem(key, JSON.stringify(value));
+			}
+		} catch (error) {
+			console.error(error);
+		}
+	}, [key, value]);
+
+	return [value, setValue];
+};
+
+export default useLocalStorage;


### PR DESCRIPTION
## What
Added code editor and other components and packages related to it.

## Details
- Used @monaco-editor/react for the code editor, and monaco-editor as a peer dependency for it.
- Monaco editor is the same editor used by VS Code.
- Added a settings modal used for settings (Mainly font size for now)
- Storing the settings in localStorage using the newly added `useLocalStorage` hook
- Added a preference nav component that holds the language selection dropdown, reset code button, settings button (which opens the settings modal) and fullscreen button
- Added editor footer which is a component that holds run, submit and cancel buttons. It is shared between code editor and console.
- Added code editor component as well